### PR TITLE
Global configuration topic ignored when project topic is not configured.

### DIFF
--- a/src/main/java/hudson/plugins/humbug/HumbugNotifier.java
+++ b/src/main/java/hudson/plugins/humbug/HumbugNotifier.java
@@ -75,7 +75,7 @@ public class HumbugNotifier extends Publisher implements SimpleBuildStep {
 
     private boolean publish(Run<?, ?> build) {
         if (shouldPublish(build)) {
-            String configuredTopic = topic != null ? topic : DESCRIPTOR.getTopic();
+            String configuredTopic = HumbugUtil.getDefaultValue(topic, DESCRIPTOR.getTopic());
             Result result = getBuildResult(build);
             String changeString = "";
             try {

--- a/src/test/java/hudson/plugins/humbug/HumbugNotifierTest.java
+++ b/src/test/java/hudson/plugins/humbug/HumbugNotifierTest.java
@@ -103,6 +103,14 @@ public class HumbugNotifierTest {
         assertEquals("Should use default stream", "defaultStream", streamCaptor.getValue());
         assertEquals("Should use default topic", "defaultTopic", topicCaptor.getValue());
         assertEquals("Message should be successful build", "**Project: **TestJob : **Build: **#1: **SUCCESS** :check_mark:", messageCaptor.getValue());
+        // Test with blank values
+        reset(humbug);
+        notifier.setStream("");
+        notifier.setTopic("");
+        notifier.perform(build, null, null);
+        verify(humbug).sendStreamMessage(streamCaptor.capture(), topicCaptor.capture(), messageCaptor.capture());
+        assertEquals("Should use default stream", "defaultStream", streamCaptor.getValue());
+        assertEquals("Should use default topic", "defaultTopic", topicCaptor.getValue());
     }
 
     @Test

--- a/src/test/java/hudson/plugins/humbug/HumbugSendStepTest.java
+++ b/src/test/java/hudson/plugins/humbug/HumbugSendStepTest.java
@@ -20,6 +20,7 @@ import org.powermock.modules.junit4.PowerMockRunner;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.verify;
 import static org.powermock.api.mockito.PowerMockito.verifyNew;
 import static org.powermock.api.mockito.PowerMockito.when;
@@ -92,6 +93,14 @@ public class HumbugSendStepTest {
         assertEquals("Should be default stream", "defaultStream", streamCaptor.getValue());
         assertEquals("Should be default topic", "defaultTopic", topicCaptor.getValue());
         assertEquals("message", messageCaptor.getValue());
+        //
+        reset(humbug);
+        sendStep.setStream("");
+        sendStep.setTopic("");
+        sendStep.perform(run, null, null, taskListener);
+        verify(humbug).sendStreamMessage(streamCaptor.capture(), topicCaptor.capture(), messageCaptor.capture());
+        assertEquals("Should be default stream", "defaultStream", streamCaptor.getValue());
+        assertEquals("Should be default topic", "defaultTopic", topicCaptor.getValue());
     }
 
     @Test


### PR DESCRIPTION
Fix of issue #9 