### PR TITLE
Release preparations

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -122,9 +122,6 @@
         <groupId>org.jenkins-ci.tools</groupId>
         <artifactId>maven-hpi-plugin</artifactId>
         <extensions>true</extensions>
-        <configuration>
-          <compatibleSinceVersion>2.0</compatibleSinceVersion>
-        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/pom.xml
+++ b/pom.xml
@@ -134,6 +134,11 @@
       <organization>Zulip</organization>
       <organizationUrl>https://zulip.com/</organizationUrl>
     </developer>
+    <developer>
+      <id>butchyyyy</id>
+      <name>Milan Koníř</name>
+      <email>Konir.M@gmail.com</email>
+    </developer>
   </developers>
 
   <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 
   <artifactId>humbug</artifactId>
   <packaging>hpi</packaging>
-  <version>0.1.4-SNAPSHOT</version>
+  <version>1.0.0-SNAPSHOT</version>
   <name>Jenkins Zulip Plugin</name>
   <description>A build status notifier that sends notifications to Zulip</description>
   <url>https://wiki.jenkins-ci.org/display/JENKINS/Humbug+Plugin</url>


### PR DESCRIPTION
pom.xml changes to prepare for release of new version:
* Bump version to new major release 1.0.0
* Add myself to the plugin developers
* Remove `<compatibleSinceVersion>` since this is only used when new version is not compatible with configurations from older versions. This is not the case and the 2.0 version was invalid anyhow.