### PR TITLE
Add personal notify feature

### DIFF
--- a/src/main/java/jenkins/plugins/zulip/CommitInfo.java
+++ b/src/main/java/jenkins/plugins/zulip/CommitInfo.java
@@ -1,0 +1,17 @@
+package jenkins.plugins.zulip;
+
+/**
+ * Commit decscription useful for holding parsed commits and sending private notifications
+ * to users using email as Zulip user ID.
+ */
+public class CommitInfo {
+    public final String author;
+    public final String email;
+    public final String message;
+
+    public CommitInfo(String author, String email, String message) {
+        this.author = author;
+        this.email = email;
+        this.message = message;
+    }
+}

--- a/src/main/java/jenkins/plugins/zulip/DescriptorImpl.java
+++ b/src/main/java/jenkins/plugins/zulip/DescriptorImpl.java
@@ -34,6 +34,7 @@ public class DescriptorImpl extends BuildStepDescriptor<Publisher> {
     private transient String hudsonUrl; // backwards compatibility
     private String jenkinsUrl;
     private boolean smartNotify;
+    private boolean personalNotify;
 
     public DescriptorImpl() {
         super(ZulipNotifier.class);
@@ -110,6 +111,14 @@ public class DescriptorImpl extends BuildStepDescriptor<Publisher> {
         this.smartNotify = smartNotify;
     }
 
+    public boolean isPersonalNotify() {
+        return personalNotify;
+    }
+
+    public void setPersonalNotify(boolean personalNotify) {
+        this.personalNotify = personalNotify;
+    }
+
     public boolean isApplicable(Class<? extends AbstractProject> aClass) {
         return true;
     }
@@ -123,6 +132,7 @@ public class DescriptorImpl extends BuildStepDescriptor<Publisher> {
         topic = (String) json.get("topic");
         jenkinsUrl = (String) json.get("jenkinsUrl");
         smartNotify = Boolean.TRUE.equals(json.get("smartNotify"));
+        personalNotify = Boolean.TRUE.equals(json.get("personalNotify"));
         save();
 
         // Cleanup the configuration file from previous plugin id - humbug

--- a/src/main/java/jenkins/plugins/zulip/Zulip.java
+++ b/src/main/java/jenkins/plugins/zulip/Zulip.java
@@ -137,4 +137,13 @@ public class Zulip {
                                 new NameValuePair("content", message)};
         return post("messages", body);
     }
+
+    public String sendPrivateMessage(String addressee, String message) {
+        NameValuePair[] body = {new NameValuePair("api-key", this.getApiKey()),
+                                new NameValuePair("email",   this.getEmail()),
+                                new NameValuePair("type",    "private"),
+                                new NameValuePair("to",      addressee),
+                                new NameValuePair("content", message)};
+        return post("messages", body);
+    }
 }

--- a/src/main/resources/jenkins/plugins/zulip/ZulipNotifier/global.jelly
+++ b/src/main/resources/jenkins/plugins/zulip/ZulipNotifier/global.jelly
@@ -32,6 +32,9 @@
     <f:entry title="Enable Smart Notification" help="/plugin/zulip/help-globalConfig-smartNotify.html">
         <f:checkbox name="smartNotify" checked="${descriptor.isSmartNotify()}" />
     </f:entry>
+    <f:entry title="Send Notifications Personally" help="/plugin/zulip/help-globalConfig-personalNotify.html">
+        <f:checkbox name="personalNotify" checked="${descriptor.isPersonalNotify()}" />
+    </f:entry>
     <f:entry title="Jenkins URL" help="/plugin/zulip/help-globalConfig-jenkinsUrl.html">
         <f:textbox name="jenkinsUrl" value="${descriptor.getJenkinsUrl()}" />
     </f:entry>

--- a/src/main/webapp/help-globalConfig-personalNotify.html
+++ b/src/main/webapp/help-globalConfig-personalNotify.html
@@ -1,0 +1,5 @@
+<div>
+    <p>When checked, build notifications will be posted to committers as private messages.</p>
+    <p><b>Note:</b> This works for Git/Mercurial repositories when users use the same e-mail
+    addresses both on the Zulip server and as the committer's name.</b></p>
+</div>


### PR DESCRIPTION
With this code `ZulipNotifier` along with messages to some stream/topic will send personal notifications to code committers.

I didn't update `README.markdown` yet but I surely do it once you decide that the changes are worthy.

Another thing. `zulipPersonalSend` similar to `zulipSend` can be useful and I can add it too.