### PR TITLE
Use the full display name of projects in notifications

### DIFF
--- a/src/main/java/jenkins/plugins/zulip/DescriptorImpl.java
+++ b/src/main/java/jenkins/plugins/zulip/DescriptorImpl.java
@@ -31,6 +31,8 @@ public class DescriptorImpl extends BuildStepDescriptor<Publisher> {
     private Secret apiKey;
     private String stream;
     private String topic;
+    private boolean fullJobPathAsDefaultTopic;
+    private boolean fullJobPathInMessage;
     private transient String hudsonUrl; // backwards compatibility
     private String jenkinsUrl;
     private boolean smartNotify;
@@ -92,6 +94,22 @@ public class DescriptorImpl extends BuildStepDescriptor<Publisher> {
 
     public void setTopic(String topic) {
         this.topic = topic;
+    }
+
+    public boolean isFullJobPathAsDefaultTopic() {
+        return fullJobPathAsDefaultTopic;
+    }
+
+    public void setFullJobPathAsDefaultTopic(boolean fullJobPathAsDefaultTopic) {
+        this.fullJobPathAsDefaultTopic = fullJobPathAsDefaultTopic;
+    }
+
+    public boolean isFullJobPathInMessage() {
+        return fullJobPathInMessage;
+    }
+
+    public void setFullJobPathInMessage(boolean fullJobPathInMessage) {
+        this.fullJobPathInMessage = fullJobPathInMessage;
     }
 
     public String getJenkinsUrl() {

--- a/src/main/java/jenkins/plugins/zulip/DescriptorImpl.java
+++ b/src/main/java/jenkins/plugins/zulip/DescriptorImpl.java
@@ -139,6 +139,8 @@ public class DescriptorImpl extends BuildStepDescriptor<Publisher> {
         apiKey = Secret.fromString((String) json.get("apiKey"));
         stream = (String) json.get("stream");
         topic = (String) json.get("topic");
+        fullJobPathAsDefaultTopic = Boolean.TRUE.equals(json.get("fullJobPathAsDefaultTopic"));
+        fullJobPathInMessage = Boolean.TRUE.equals(json.get("fullJobPathInMessage"));
         jenkinsUrl = (String) json.get("jenkinsUrl");
         smartNotify = Boolean.TRUE.equals(json.get("smartNotify"));
         save();

--- a/src/main/java/jenkins/plugins/zulip/ZulipNotifier.java
+++ b/src/main/java/jenkins/plugins/zulip/ZulipNotifier.java
@@ -1,11 +1,5 @@
 package jenkins.plugins.zulip;
 
-import java.io.IOException;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
-import javax.annotation.Nonnull;
-
 import hudson.Extension;
 import hudson.FilePath;
 import hudson.Launcher;
@@ -22,6 +16,13 @@ import jenkins.tasks.SimpleBuildStep;
 import org.apache.commons.lang.exception.ExceptionUtils;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
+
+import javax.annotation.Nonnull;
+import java.io.IOException;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import static jenkins.plugins.zulip.ZulipUtil.displayObjectWithLink;
 
 /**
  * Sends build result notification to stream based on the configuration
@@ -101,9 +102,9 @@ public class ZulipNotifier extends Publisher implements SimpleBuildStep {
             String message = "";
             // If we are sending to fixed topic, we will want to add project name into the message
             if (ZulipUtil.isValueSet(configuredTopic)) {
-                message += hundsonUrlMesssage("Project: ", build.getParent().getDisplayName(), build.getParent().getUrl(), DESCRIPTOR) + " : ";
+                message += "**Project: **" + displayObjectWithLink(build.getParent(), build.getParent().getUrl(), DESCRIPTOR) + " : ";
             }
-            message += hundsonUrlMesssage("Build: ", build.getDisplayName(), build.getUrl(), DESCRIPTOR);
+            message += "**Build: **" + displayObjectWithLink(build, build.getUrl(), DESCRIPTOR);
             message += ": ";
             message += "**" + resultString + "**";
             if (result == Result.SUCCESS) {
@@ -176,25 +177,6 @@ public class ZulipNotifier extends Publisher implements SimpleBuildStep {
             return true;
         }
         return false;
-    }
-
-    /**
-     * Helper method to format build parameter as link to Jenkins with prefix
-     *
-     * @param prefix       The prefix to add to the parameter (will be formatted as bold)
-     * @param display      The build parameter
-     * @param url          The Url to the Jenkins item
-     * @param globalConfig Global step config
-     * @return Formatted parameter
-     */
-    private static String hundsonUrlMesssage(String prefix, String display, String url, DescriptorImpl globalConfig) {
-        String message = display;
-        String jenkinsUrl = ZulipUtil.getJenkinsUrl(globalConfig);
-        if (ZulipUtil.isValueSet(jenkinsUrl)) {
-            message = "[" + message + "](" + jenkinsUrl + url + ")";
-        }
-        message = "**" + prefix + "**" + message;
-        return message;
     }
 
     /**

--- a/src/main/java/jenkins/plugins/zulip/ZulipNotifier.java
+++ b/src/main/java/jenkins/plugins/zulip/ZulipNotifier.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import static jenkins.plugins.zulip.ZulipUtil.displayItem;
 import static jenkins.plugins.zulip.ZulipUtil.displayObjectWithLink;
 
 /**
@@ -102,7 +103,9 @@ public class ZulipNotifier extends Publisher implements SimpleBuildStep {
             String message = "";
             // If we are sending to fixed topic, we will want to add project name into the message
             if (ZulipUtil.isValueSet(configuredTopic)) {
-                message += "**Project: **" + displayObjectWithLink(build.getParent(), build.getParent().getUrl(), DESCRIPTOR) + " : ";
+                message += "**Project: **"
+                        + displayItem(build.getParent(), DESCRIPTOR, DESCRIPTOR.isFullJobPathInMessage(), true)
+                        + " : ";
             }
             message += "**Build: **" + displayObjectWithLink(build, build.getUrl(), DESCRIPTOR);
             message += ": ";
@@ -124,8 +127,9 @@ public class ZulipNotifier extends Publisher implements SimpleBuildStep {
             }
             String destinationStream =
                     ZulipUtil.expandVariables(build, listener, ZulipUtil.getDefaultValue(stream, DESCRIPTOR.getStream()));
+            String defaultTopic = displayItem(build.getParent(), DESCRIPTOR, DESCRIPTOR.isFullJobPathAsDefaultTopic(), false);
             String destinationTopic = ZulipUtil.expandVariables(build, listener,
-                    ZulipUtil.getDefaultValue(configuredTopic, build.getParent().getDisplayName()));
+                    ZulipUtil.getDefaultValue(configuredTopic, defaultTopic));
             Zulip zulip = new Zulip(DESCRIPTOR.getUrl(), DESCRIPTOR.getEmail(), DESCRIPTOR.getApiKey());
             zulip.sendStreamMessage(destinationStream, destinationTopic, message);
         }

--- a/src/main/java/jenkins/plugins/zulip/ZulipSendStep.java
+++ b/src/main/java/jenkins/plugins/zulip/ZulipSendStep.java
@@ -19,6 +19,8 @@ import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 
+import static jenkins.plugins.zulip.ZulipUtil.displayItem;
+
 /**
  * Sends arbitrary message to Zulip stream
  */
@@ -41,9 +43,9 @@ public class ZulipSendStep extends Builder implements SimpleBuildStep {
                 Jenkins.getInstance().getDescriptorByType(jenkins.plugins.zulip.DescriptorImpl.class);
         Zulip zulip = new Zulip(globalConfig.getUrl(), globalConfig.getEmail(), globalConfig.getApiKey());
         String stream = ZulipUtil.expandVariables(run, listener, ZulipUtil.getDefaultValue(getStream(), globalConfig.getStream()));
+        String defaultTopic = displayItem(run.getParent(), globalConfig, globalConfig.isFullJobPathAsDefaultTopic(), false);
         String topic = ZulipUtil.expandVariables(run, listener,
-                ZulipUtil.getDefaultValue(ZulipUtil.getDefaultValue(getTopic(), globalConfig.getTopic()),
-                        run.getParent().getDisplayName()));
+                ZulipUtil.getDefaultValue(ZulipUtil.getDefaultValue(getTopic(), globalConfig.getTopic()), defaultTopic));
         String message = ZulipUtil.expandVariables(run, listener, getMessage());
         zulip.sendStreamMessage(stream, topic, message);
     }

--- a/src/main/java/jenkins/plugins/zulip/ZulipUtil.java
+++ b/src/main/java/jenkins/plugins/zulip/ZulipUtil.java
@@ -5,6 +5,7 @@ import java.util.logging.Logger;
 
 import javax.annotation.Nonnull;
 
+import hudson.model.ModelObject;
 import hudson.model.Run;
 import hudson.model.TaskListener;
 import jenkins.model.Jenkins;
@@ -71,6 +72,25 @@ public class ZulipUtil {
             logger.severe("Failed to expand message variables: " + ex.getMessage());
         }
         return expandedMessage;
+    }
+
+    /**
+     * Helper method to display a Jenkins model object with a link.
+     *
+     * @param object       The Jenkins model object (item, run, ...)
+     * @param url          The Url to the Jenkins model object
+     * @param globalConfig Zulip global configuration
+     * @return A string representing the Jenkins model object, with a link if possible.
+     */
+    public static String displayObjectWithLink(ModelObject object, String url, DescriptorImpl globalConfig) {
+        String message = object.getDisplayName();
+        if (url != null) {
+            String jenkinsUrl = ZulipUtil.getJenkinsUrl(globalConfig);
+            if (ZulipUtil.isValueSet(jenkinsUrl)) {
+                message = "[" + message + "](" + jenkinsUrl + url + ")";
+            }
+        }
+        return message;
     }
 
 }

--- a/src/main/java/jenkins/plugins/zulip/ZulipUtil.java
+++ b/src/main/java/jenkins/plugins/zulip/ZulipUtil.java
@@ -105,6 +105,10 @@ public class ZulipUtil {
      */
     private static void displayObject(StringBuilder builder, ModelObject object, String url, DescriptorImpl globalConfig,
                                       boolean fullPath, boolean displayLinks) {
+        // We never display Jenkins; it's implicit.
+        if (object instanceof jenkins.model.Jenkins) {
+            return;
+        }
         // The only common interface between Item and ItemGroup is ModelObject, which doesn't define getParent,
         // so we need to resort to instanceof + cast to crawl up the item tree.
         if (fullPath && object instanceof Item) {

--- a/src/main/java/jenkins/plugins/zulip/ZulipUtil.java
+++ b/src/main/java/jenkins/plugins/zulip/ZulipUtil.java
@@ -1,14 +1,16 @@
 package jenkins.plugins.zulip;
 
-import java.io.IOException;
-import java.util.logging.Logger;
-
-import javax.annotation.Nonnull;
-
+import hudson.model.Item;
+import hudson.model.ItemGroup;
+import hudson.model.Job;
 import hudson.model.ModelObject;
 import hudson.model.Run;
 import hudson.model.TaskListener;
 import jenkins.model.Jenkins;
+
+import javax.annotation.Nonnull;
+import java.io.IOException;
+import java.util.logging.Logger;
 
 /**
  * Static helper methods
@@ -72,6 +74,52 @@ public class ZulipUtil {
             logger.severe("Failed to expand message variables: " + ex.getMessage());
         }
         return expandedMessage;
+    }
+
+    /**
+     * Helper method to display an item, optionally with links.
+     *
+     * @param item         The item to display.
+     * @param globalConfig Zulip global configuration.
+     * @param fullPath     Whether to display the full path including the display name of parent items
+     *                     ({@code true}) or just this item's display name ({@code false}).
+     * @param displayLinks Whether to display links to the item and (if relevant) its parent items.
+     * @return A string representing the item.
+     */
+    public static String displayItem(Item item, DescriptorImpl globalConfig, boolean fullPath, boolean displayLinks) {
+        StringBuilder builder = new StringBuilder();
+        // Don't call getUrl() unless necessary: the logic behind that method is complex.
+        displayObject(builder, item, displayLinks ? item.getUrl() : null, globalConfig, fullPath, displayLinks);
+        return builder.toString();
+    }
+
+    /**
+     * Helper method to display a model object, optionally with links.
+     *
+     * @param builder      The builder to append to.
+     * @param object       The object to display.
+     * @param globalConfig Zulip global configuration.
+     * @param fullPath     Whether to display the full path including the display name of parent items
+     *                     ({@code true}) or just this object's display name ({@code false}).
+     * @param displayLinks Whether to display links to the object and (if relevant) its parent items.
+     */
+    private static void displayObject(StringBuilder builder, ModelObject object, String url, DescriptorImpl globalConfig,
+                                      boolean fullPath, boolean displayLinks) {
+        // The only common interface between Item and ItemGroup is ModelObject, which doesn't define getParent,
+        // so we need to resort to instanceof + cast to crawl up the item tree.
+        if (fullPath && object instanceof Item) {
+            ItemGroup<?> parent = ((Item) object).getParent();
+            int lengthBefore = builder.length();
+            // Don't call getUrl() unless necessary: the logic behind that method is complex.
+            displayObject(builder, parent, displayLinks ? parent.getUrl() : null, globalConfig, fullPath, displayLinks);
+            if (builder.length() != lengthBefore) {
+                builder.append(" » ");
+            }
+        }
+        String displayName = object.getDisplayName();
+        if ( displayName != null && !displayName.isEmpty() ) {
+            builder.append(displayObjectWithLink(object, displayLinks ? url : null, globalConfig));
+        }
     }
 
     /**

--- a/src/main/resources/jenkins/plugins/zulip/ZulipNotifier/global.jelly
+++ b/src/main/resources/jenkins/plugins/zulip/ZulipNotifier/global.jelly
@@ -29,6 +29,12 @@
     <f:entry title="Default Topic Name" help="/plugin/zulip/help-globalConfig-topic.html">
         <f:textbox name="topic" value="${descriptor.getTopic()}" />
     </f:entry>
+    <f:entry title="Use full job path in default topic name" help="/plugin/zulip/help-globalConfig-fullJobPathAsDefaultTopic.html">
+        <f:checkbox name="fullJobPathAsDefaultTopic" checked="${descriptor.isFullJobPathAsDefaultTopic()}" />
+    </f:entry>
+    <f:entry title="Use full job path in notification message" help="/plugin/zulip/help-globalConfig-fullJobPathInMessage.html">
+        <f:checkbox name="fullJobPathInMessage" checked="${descriptor.isFullJobPathInMessage()}" />
+    </f:entry>
     <f:entry title="Enable Smart Notification" help="/plugin/zulip/help-globalConfig-smartNotify.html">
         <f:checkbox name="smartNotify" checked="${descriptor.isSmartNotify()}" />
     </f:entry>

--- a/src/main/webapp/help-globalConfig-fullJobPathAsDefaultTopic.html
+++ b/src/main/webapp/help-globalConfig-fullJobPathAsDefaultTopic.html
@@ -1,0 +1,16 @@
+<div>
+    <p>When checked, the topic will default to the full path of the job, including parent directories and parent
+        jobs.</p>
+    <p>This only has an effect when no topic is configured explicitly.</p>
+    <p>This is especially useful for multi-branch pipelines: the topic will include both the name of the pipeline
+        and the name of the branch, instead of just the name of the branch.
+    </p>
+    <p>
+        For example in a multi-branch pipeline job named "My Job",
+        for a notification on branch "main":
+    </p>
+    <ul>
+        <li>with this option left unchecked, the topic will default to "main"</li>
+        <li>with this option checked, the topic will default to "My Job » main"</li>
+    </ul>
+</div>

--- a/src/main/webapp/help-globalConfig-fullJobPathInMessage.html
+++ b/src/main/webapp/help-globalConfig-fullJobPathInMessage.html
@@ -1,0 +1,14 @@
+<div>
+    <p>When checked, notification messages will include the full path of the job, including parent directories and
+        parent jobs, with a link to each of them.</p>
+    <p>This is especially useful for multi-branch pipelines: the message will include both the name of the pipeline
+        and the name of the branch, instead of just the name of the branch.</p>
+    <p>
+        For example in a multi-branch pipeline job named "My Job",
+        for a notification on branch "main":
+    </p>
+    <ul>
+        <li>with this option left unchecked, the notification message will start with "Project: main"</li>
+        <li>with this option checked, the notification message will start with "Project: My Job » main"</li>
+    </ul>
+</div>

--- a/src/test/java/jenkins/plugins/zulip/ItemAndItemGroup.java
+++ b/src/test/java/jenkins/plugins/zulip/ItemAndItemGroup.java
@@ -1,0 +1,9 @@
+package jenkins.plugins.zulip;
+
+import hudson.model.Item;
+import hudson.model.ItemGroup;
+
+// @Mock(extraInterfaces = Item.class) won't work for some reason,
+// so we define our own interface that combine the two we want to mock.
+interface ItemAndItemGroup<I extends Item> extends Item, ItemGroup<I> {
+}

--- a/src/test/java/jenkins/plugins/zulip/ZulipNotifierFullJobPathTest.java
+++ b/src/test/java/jenkins/plugins/zulip/ZulipNotifierFullJobPathTest.java
@@ -1,0 +1,202 @@
+package jenkins.plugins.zulip;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import hudson.EnvVars;
+import hudson.model.AbstractBuild;
+import hudson.model.BuildListener;
+import hudson.model.ItemGroup;
+import hudson.model.Job;
+import hudson.model.Result;
+import hudson.model.Run;
+import hudson.model.User;
+import hudson.scm.ChangeLogSet;
+import hudson.tasks.test.AbstractTestResultAction;
+import hudson.util.Secret;
+import jenkins.model.Jenkins;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.jvnet.hudson.test.FakeChangeLogSCM;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+import org.powermock.reflect.Whitebox;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyBoolean;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.powermock.api.mockito.PowerMockito.verifyNew;
+import static org.powermock.api.mockito.PowerMockito.when;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({Jenkins.class, User.class, ZulipNotifier.class, DescriptorImpl.class,
+        AbstractBuild.class, Job.class, Secret.class, SmartNotification.class})
+public class ZulipNotifierFullJobPathTest {
+
+    @Mock
+    private Jenkins jenkins;
+
+    @Mock
+    private Secret secret;
+
+    @Mock
+    private Zulip zulip;
+
+    @Mock
+    private DescriptorImpl descMock;
+
+    @Mock
+    private AbstractBuild build;
+
+    @Mock
+    private Job job;
+
+    @Mock
+    private ItemGroup<?> folder;
+
+    @Mock
+    private BuildListener buildListener;
+
+    @Mock
+    private EnvVars envVars;
+
+    @Captor
+    private ArgumentCaptor<String> expandCaptor;
+
+    @Captor
+    private ArgumentCaptor<String> streamCaptor;
+
+    @Captor
+    private ArgumentCaptor<String> topicCaptor;
+
+    @Captor
+    private ArgumentCaptor<String> messageCaptor;
+
+    @Before
+    public void setUp() throws Exception {
+        PowerMockito.whenNew(Zulip.class).withAnyArguments().thenReturn(zulip);
+        PowerMockito.mockStatic(Jenkins.class);
+        when(Jenkins.getInstance()).thenReturn(jenkins);
+        PowerMockito.mockStatic(User.class);
+        when(User.get(anyString())).thenAnswer(new Answer<User>() {
+            @Override
+            public User answer(InvocationOnMock invocation) throws Throwable {
+                String arg = (String) invocation.getArguments()[0];
+                User userMock = PowerMockito.mock(User.class);
+                when(userMock.getDisplayName()).thenReturn(arg);
+                return userMock;
+            }
+        });
+        when(descMock.getUrl()).thenReturn("zulipUrl");
+        when(descMock.getEmail()).thenReturn("jenkins-bot@zulip.com");
+        when(descMock.getApiKey()).thenReturn(secret);
+        when(descMock.getStream()).thenReturn("defaultStream");
+        when(descMock.getTopic()).thenReturn("defaultTopic");
+        when(descMock.isFullJobPathAsDefaultTopic()).thenReturn(true);
+        when(descMock.isFullJobPathInMessage()).thenReturn(true);
+        PowerMockito.whenNew(DescriptorImpl.class).withAnyArguments().thenReturn(descMock);
+        when(build.getParent()).thenReturn(job);
+        when(build.getDisplayName()).thenReturn("#1");
+        when(build.getUrl()).thenReturn("job/Folder/TestJob/1");
+        when(build.hasChangeSetComputed()).thenReturn(true);
+        when(build.getChangeSet()).thenReturn(ChangeLogSet.createEmpty((Run<?, ?>) build));
+        when(job.getDisplayName()).thenReturn("TestJob");
+        when(job.getUrl()).thenReturn("job/Folder/TestJob");
+        when(job.getParent()).thenReturn(folder);
+        when(folder.getDisplayName()).thenReturn("Folder");
+        when(folder.getUrl()).thenReturn("job/Folder");
+        when(build.getEnvironment(buildListener)).thenReturn(envVars);
+        when(envVars.expand(anyString())).thenAnswer(new Answer<String>() {
+            @Override
+            public String answer(InvocationOnMock invocation) throws Throwable {
+                return (String) invocation.getArguments()[0];
+            }
+        });
+        PowerMockito.mockStatic(SmartNotification.class);
+        when(SmartNotification.isSmartNotifyEnabled(anyString(), anyBoolean())).thenReturn(false);
+    }
+
+    @Test
+    public void testShouldUseDefaults() throws Exception {
+        ZulipNotifier notifier = new ZulipNotifier();
+        notifier.perform(build, null, buildListener);
+        verifyNew(Zulip.class).withArguments(eq("zulipUrl"), eq("jenkins-bot@zulip.com"), any(Secret.class));
+        verify(envVars, times(2)).expand(expandCaptor.capture());
+        assertThat("Should expand stream, topic and message", expandCaptor.getAllValues(),
+                is(Arrays.asList("defaultStream", "defaultTopic")));
+        verify(zulip).sendStreamMessage(streamCaptor.capture(), topicCaptor.capture(), messageCaptor.capture());
+        assertEquals("Should use default stream", "defaultStream", streamCaptor.getValue());
+        assertEquals("Should use default topic", "defaultTopic", topicCaptor.getValue());
+        assertEquals("Message should be successful build", "**Project: **Folder » TestJob : **Build: **#1: **SUCCESS** :check_mark:", messageCaptor.getValue());
+        // Test with blank values
+        reset(zulip);
+        notifier.setStream("");
+        notifier.setTopic("");
+        notifier.perform(build, null, buildListener);
+        verify(zulip).sendStreamMessage(streamCaptor.capture(), topicCaptor.capture(), messageCaptor.capture());
+        assertEquals("Should use default stream", "defaultStream", streamCaptor.getValue());
+        assertEquals("Should use default topic", "defaultTopic", topicCaptor.getValue());
+    }
+
+    @Test
+    public void testShouldUseProjectConfig() throws Exception {
+        ZulipNotifier notifier = new ZulipNotifier();
+        notifier.setStream("projectStream");
+        notifier.setTopic("projectTopic");
+        notifier.perform(build, null, buildListener);
+        verify(zulip).sendStreamMessage(streamCaptor.capture(), topicCaptor.capture(), messageCaptor.capture());
+        assertEquals("Should use project stream", "projectStream", streamCaptor.getValue());
+        assertEquals("Should use topic stream", "projectTopic", topicCaptor.getValue());
+    }
+
+    @Test
+    public void testShouldUseFullJobPathAsTopic() throws Exception {
+        try {
+            ZulipNotifier notifier = new ZulipNotifier();
+            when(descMock.getTopic()).thenReturn("");
+            Whitebox.setInternalState(ZulipNotifier.class, descMock);
+            notifier.perform(build, null, buildListener);
+            verify(zulip).sendStreamMessage(streamCaptor.capture(), topicCaptor.capture(), messageCaptor.capture());
+            assertEquals("Topic should be project's full job path", "Folder » TestJob", topicCaptor.getValue());
+            assertEquals("Message should not contain project name", "**Build: **#1: **SUCCESS** :check_mark:", messageCaptor.getValue());
+        } finally {
+            // Be sure to return global setting back to original setup so other tests dont fail
+            when(descMock.getTopic()).thenReturn("defaultTopic");
+            Whitebox.setInternalState(ZulipNotifier.class, descMock);
+        }
+    }
+
+    @Test
+    public void testJenkinsUrl() throws Exception {
+        try {
+            ZulipNotifier notifier = new ZulipNotifier();
+            when(descMock.getJenkinsUrl()).thenReturn("JenkinsUrl");
+            Whitebox.setInternalState(ZulipNotifier.class, descMock);
+            notifier.perform(build, null, buildListener);
+            verify(zulip).sendStreamMessage(streamCaptor.capture(), topicCaptor.capture(), messageCaptor.capture());
+            assertEquals("Message should contain links to Jenkins",
+                    "**Project: **[Folder](JenkinsUrl/job/Folder) » [TestJob](JenkinsUrl/job/Folder/TestJob) : **Build: **[#1](JenkinsUrl/job/Folder/TestJob/1): **SUCCESS** :check_mark:",
+                    messageCaptor.getValue());
+        } finally {
+            // Be sure to return global setting back to original setup so other tests dont fail
+            when(descMock.getJenkinsUrl()).thenReturn("");
+            Whitebox.setInternalState(ZulipNotifier.class, descMock);
+        }
+    }
+
+}

--- a/src/test/java/jenkins/plugins/zulip/ZulipNotifierFullJobPathTest.java
+++ b/src/test/java/jenkins/plugins/zulip/ZulipNotifierFullJobPathTest.java
@@ -67,7 +67,7 @@ public class ZulipNotifierFullJobPathTest {
     private Job job;
 
     @Mock
-    private ItemGroup<?> folder;
+    private ItemAndItemGroup<?> folder;
 
     @Mock
     private BuildListener buildListener;
@@ -92,6 +92,7 @@ public class ZulipNotifierFullJobPathTest {
         PowerMockito.whenNew(Zulip.class).withAnyArguments().thenReturn(zulip);
         PowerMockito.mockStatic(Jenkins.class);
         when(Jenkins.getInstance()).thenReturn(jenkins);
+        when(jenkins.getDisplayName()).thenReturn("Jenkins");
         PowerMockito.mockStatic(User.class);
         when(User.get(anyString())).thenAnswer(new Answer<User>() {
             @Override
@@ -120,6 +121,7 @@ public class ZulipNotifierFullJobPathTest {
         when(job.getParent()).thenReturn(folder);
         when(folder.getDisplayName()).thenReturn("Folder");
         when(folder.getUrl()).thenReturn("job/Folder");
+        when(folder.getParent()).thenReturn((ItemGroup)jenkins);
         when(build.getEnvironment(buildListener)).thenReturn(envVars);
         when(envVars.expand(anyString())).thenAnswer(new Answer<String>() {
             @Override

--- a/src/test/java/jenkins/plugins/zulip/ZulipSendStepFullJobPathTest.java
+++ b/src/test/java/jenkins/plugins/zulip/ZulipSendStepFullJobPathTest.java
@@ -57,7 +57,7 @@ public class ZulipSendStepFullJobPathTest {
     private Job job;
 
     @Mock
-    private ItemGroup<?> folder;
+    private ItemAndItemGroup<?> folder;
 
     @Mock
     private TaskListener taskListener;
@@ -83,6 +83,7 @@ public class ZulipSendStepFullJobPathTest {
         PowerMockito.mockStatic(Jenkins.class);
         when(Jenkins.getInstance()).thenReturn(jenkins);
         when(jenkins.getDescriptorByType(DescriptorImpl.class)).thenReturn(descMock);
+        when(jenkins.getDisplayName()).thenReturn("Jenkins");
         when(descMock.getUrl()).thenReturn("zulipUrl");
         when(descMock.getEmail()).thenReturn("jenkins-bot@zulip.com");
         when(descMock.getApiKey()).thenReturn(secret);
@@ -94,6 +95,7 @@ public class ZulipSendStepFullJobPathTest {
         when(job.getParent()).thenReturn(folder);
         when(folder.getDisplayName()).thenReturn("Folder");
         when(folder.getUrl()).thenReturn("job/Folder");
+        when(folder.getParent()).thenReturn((ItemGroup)jenkins);
         when(run.getEnvironment(taskListener)).thenReturn(envVars);
         when(envVars.expand(anyString())).thenAnswer(new Answer<String>() {
             @Override

--- a/src/test/java/jenkins/plugins/zulip/ZulipSendStepFullJobPathTest.java
+++ b/src/test/java/jenkins/plugins/zulip/ZulipSendStepFullJobPathTest.java
@@ -1,0 +1,150 @@
+package jenkins.plugins.zulip;
+
+import hudson.EnvVars;
+import hudson.model.ItemGroup;
+import hudson.model.Job;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import hudson.util.Secret;
+import jenkins.model.Jenkins;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.util.Arrays;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.powermock.api.mockito.PowerMockito.verifyNew;
+import static org.powermock.api.mockito.PowerMockito.when;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({Jenkins.class, ZulipSendStep.class, Secret.class})
+public class ZulipSendStepFullJobPathTest {
+
+    @Mock
+    private Jenkins jenkins;
+
+    @Mock
+    private Secret secret;
+
+    @Mock
+    private Zulip zulip;
+
+    @Mock
+    private DescriptorImpl descMock;
+
+    @Mock
+    private Run run;
+
+    @Mock
+    private Job job;
+
+    @Mock
+    private ItemGroup<?> folder;
+
+    @Mock
+    private TaskListener taskListener;
+
+    @Mock
+    private EnvVars envVars;
+
+    @Captor
+    private ArgumentCaptor<String> expandCaptor;
+
+    @Captor
+    private ArgumentCaptor<String> streamCaptor;
+
+    @Captor
+    private ArgumentCaptor<String> topicCaptor;
+
+    @Captor
+    private ArgumentCaptor<String> messageCaptor;
+
+    @Before
+    public void setUp() throws Exception {
+        PowerMockito.whenNew(Zulip.class).withAnyArguments().thenReturn(zulip);
+        PowerMockito.mockStatic(Jenkins.class);
+        when(Jenkins.getInstance()).thenReturn(jenkins);
+        when(jenkins.getDescriptorByType(DescriptorImpl.class)).thenReturn(descMock);
+        when(descMock.getUrl()).thenReturn("zulipUrl");
+        when(descMock.getEmail()).thenReturn("jenkins-bot@zulip.com");
+        when(descMock.getApiKey()).thenReturn(secret);
+        when(descMock.getStream()).thenReturn("defaultStream");
+        when(descMock.getTopic()).thenReturn("defaultTopic");
+        when(descMock.isFullJobPathAsDefaultTopic()).thenReturn(true);
+        when(run.getParent()).thenReturn(job);
+        when(job.getDisplayName()).thenReturn("TestJob");
+        when(job.getParent()).thenReturn(folder);
+        when(folder.getDisplayName()).thenReturn("Folder");
+        when(folder.getUrl()).thenReturn("job/Folder");
+        when(run.getEnvironment(taskListener)).thenReturn(envVars);
+        when(envVars.expand(anyString())).thenAnswer(new Answer<String>() {
+            @Override
+            public String answer(InvocationOnMock invocation) throws Throwable {
+                return (String) invocation.getArguments()[0];
+            }
+        });
+    }
+
+    @Test
+    public void testShouldUseDefaults() throws Exception {
+        ZulipSendStep sendStep = new ZulipSendStep();
+        sendStep.setMessage("message");
+        sendStep.perform(run, null, null, taskListener);
+        verifyNew(Zulip.class).withArguments(eq("zulipUrl"), eq("jenkins-bot@zulip.com"), any(Secret.class));
+        verify(envVars, times(3)).expand(expandCaptor.capture());
+        assertThat("Should expand stream, topic and message", expandCaptor.getAllValues(),
+                is(Arrays.asList("defaultStream", "defaultTopic", "message")));
+        verify(zulip).sendStreamMessage(streamCaptor.capture(), topicCaptor.capture(), messageCaptor.capture());
+        assertEquals("Should be default stream", "defaultStream", streamCaptor.getValue());
+        assertEquals("Should be default topic", "defaultTopic", topicCaptor.getValue());
+        assertEquals("message", messageCaptor.getValue());
+        //
+        reset(zulip);
+        sendStep.setStream("");
+        sendStep.setTopic("");
+        sendStep.perform(run, null, null, taskListener);
+        verify(zulip).sendStreamMessage(streamCaptor.capture(), topicCaptor.capture(), messageCaptor.capture());
+        assertEquals("Should be default stream", "defaultStream", streamCaptor.getValue());
+        assertEquals("Should be default topic", "defaultTopic", topicCaptor.getValue());
+    }
+
+    @Test
+    public void testShouldUseProjectConfig() throws Exception {
+        ZulipSendStep sendStep = new ZulipSendStep();
+        sendStep.setStream("projectStream");
+        sendStep.setTopic("projectTopic");
+        sendStep.perform(run, null, null, taskListener);
+        verify(zulip).sendStreamMessage(streamCaptor.capture(), topicCaptor.capture(), messageCaptor.capture());
+        assertEquals("Should be project stream", "projectStream", streamCaptor.getValue());
+        assertEquals("Should be project topic", "projectTopic", topicCaptor.getValue());
+        assertNull("Should be null message", messageCaptor.getValue());
+    }
+
+    public void testShouldUseFullJobPathAsTopic() throws Exception {
+        ZulipSendStep sendStep = new ZulipSendStep();
+        // Override default topic config
+        when(descMock.getTopic()).thenReturn("");
+        sendStep.perform(run, null, null, taskListener);
+        verify(zulip).sendStreamMessage(streamCaptor.capture(), topicCaptor.capture(), messageCaptor.capture());
+        assertEquals("Topic should be project display name", "Folder » TestJob", topicCaptor.getValue());
+    }
+
+}

--- a/src/test/java/jenkins/plugins/zulip/ZulipUtilTest.java
+++ b/src/test/java/jenkins/plugins/zulip/ZulipUtilTest.java
@@ -1,5 +1,6 @@
 package jenkins.plugins.zulip;
 
+import hudson.model.Item;
 import jenkins.model.Jenkins;
 import org.junit.Before;
 import org.junit.Test;
@@ -23,6 +24,9 @@ public class ZulipUtilTest {
 
     @Mock
     private DescriptorImpl descMock;
+
+    @Mock
+    private Item itemMock;
 
     @Before
     public void setUp() {
@@ -51,6 +55,26 @@ public class ZulipUtilTest {
         assertEquals("Expect Jenkins Configured Url", "http://JenkinsConfigUrl/", ZulipUtil.getJenkinsUrl(descMock));
         when(descMock.getJenkinsUrl()).thenReturn("http://ZulipConfigUrl/");
         assertEquals("Expect Zulip config Url", "http://ZulipConfigUrl/", ZulipUtil.getJenkinsUrl(descMock));
+    }
+
+    @Test
+    public void testDisplayObjectWithLink() {
+        when(itemMock.getDisplayName()).thenReturn("MyJobName");
+
+        // Default Jenkins root URL from the Jenkins class
+        assertEquals("[MyJobName](http://JenkinsConfigUrl/job/MyJob)", ZulipUtil.displayObjectWithLink(itemMock, "job/MyJob", descMock));
+        assertEquals("MyJobName", ZulipUtil.displayObjectWithLink(itemMock, null, descMock));
+
+        // Custom Jenkins root URL from plugin config
+        when(descMock.getJenkinsUrl()).thenReturn("http://ZulipConfigUrl/");
+        assertEquals("[MyJobName](http://ZulipConfigUrl/job/MyJob)", ZulipUtil.displayObjectWithLink(itemMock, "job/MyJob", descMock));
+        assertEquals("MyJobName", ZulipUtil.displayObjectWithLink(itemMock, null, descMock));
+
+        // No Jenkins root URL at all
+        PowerMockito.when(jenkins.getRootUrl()).thenReturn(null);
+        when(descMock.getJenkinsUrl()).thenReturn(null);
+        assertEquals("MyJobName", ZulipUtil.displayObjectWithLink(itemMock, "job/MyJob", descMock));
+        assertEquals("MyJobName", ZulipUtil.displayObjectWithLink(itemMock, null, descMock));
     }
 
 }

--- a/src/test/java/jenkins/plugins/zulip/ZulipUtilTest.java
+++ b/src/test/java/jenkins/plugins/zulip/ZulipUtilTest.java
@@ -1,6 +1,7 @@
 package jenkins.plugins.zulip;
 
 import hudson.model.Item;
+import hudson.model.ItemGroup;
 import jenkins.model.Jenkins;
 import org.junit.Before;
 import org.junit.Test;
@@ -19,11 +20,22 @@ import static org.mockito.Mockito.when;
 @PrepareForTest(Jenkins.class)
 public class ZulipUtilTest {
 
+    // @Mock(extraInterfaces = Item.class) won't work for some reason,
+    // so we define our own interface that combine the two we want to mock.
+    interface ItemAndItemGroup<I extends Item> extends Item, ItemGroup<I> {
+    }
+
     @Mock
     private Jenkins jenkins;
 
     @Mock
     private DescriptorImpl descMock;
+
+    @Mock
+    private ItemGroup<?> rootItemGroupMock;
+
+    @Mock
+    private ItemAndItemGroup<?> nonRootItemGroupMock;
 
     @Mock
     private Item itemMock;
@@ -75,6 +87,81 @@ public class ZulipUtilTest {
         when(descMock.getJenkinsUrl()).thenReturn(null);
         assertEquals("MyJobName", ZulipUtil.displayObjectWithLink(itemMock, "job/MyJob", descMock));
         assertEquals("MyJobName", ZulipUtil.displayObjectWithLink(itemMock, null, descMock));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked") // We need unchecked casts to ItemGroup (raw type) in order to mock methods that return ItemGroup<? extends Item>
+    public void testDisplayJob() {
+        when(itemMock.getDisplayName()).thenReturn("MyJobName");
+        when(itemMock.getUrl()).thenReturn("job/MyJob");
+
+        // Ancestors do have a name => Display full path when requested
+        when(itemMock.getParent()).thenReturn((ItemGroup)nonRootItemGroupMock);
+        when(nonRootItemGroupMock.getParent()).thenReturn((ItemGroup)rootItemGroupMock);
+        when(rootItemGroupMock.getDisplayName()).thenReturn("RootName");
+        when(rootItemGroupMock.getUrl()).thenReturn("view/RootUrl");
+        when(nonRootItemGroupMock.getDisplayName()).thenReturn("NonRootName");
+        when(nonRootItemGroupMock.getUrl()).thenReturn("job/NonRootUrl");
+        assertEquals("[RootName](http://JenkinsConfigUrl/view/RootUrl) » [NonRootName](http://JenkinsConfigUrl/job/NonRootUrl) » [MyJobName](http://JenkinsConfigUrl/job/MyJob)", ZulipUtil.displayItem(itemMock, descMock, true, true));
+        assertEquals("RootName » NonRootName » MyJobName", ZulipUtil.displayItem(itemMock, descMock, true, false));
+        assertEquals("[MyJobName](http://JenkinsConfigUrl/job/MyJob)", ZulipUtil.displayItem(itemMock, descMock, false, true));
+        assertEquals("MyJobName", ZulipUtil.displayItem(itemMock, descMock, false, false));
+
+        // Parent without a URL => don't add a link
+        when(itemMock.getParent()).thenReturn((ItemGroup)rootItemGroupMock);
+        when(rootItemGroupMock.getDisplayName()).thenReturn("RootName");
+        when(rootItemGroupMock.getUrl()).thenReturn(null);
+        assertEquals("RootName » [MyJobName](http://JenkinsConfigUrl/job/MyJob)", ZulipUtil.displayItem(itemMock, descMock, true, true));
+        assertEquals("RootName » MyJobName", ZulipUtil.displayItem(itemMock, descMock, true, false));
+        assertEquals("[MyJobName](http://JenkinsConfigUrl/job/MyJob)", ZulipUtil.displayItem(itemMock, descMock, false, true));
+        assertEquals("MyJobName", ZulipUtil.displayItem(itemMock, descMock, false, false));
+
+        // Parent with an empty name => display the job only
+        // This can happen: see hudson.model.AbstractItem.getFullDisplayName
+        when(itemMock.getParent()).thenReturn((ItemGroup)rootItemGroupMock);
+        when(rootItemGroupMock.getDisplayName()).thenReturn("");
+        when(rootItemGroupMock.getUrl()).thenReturn("view/RootUrl");
+        assertEquals("[MyJobName](http://JenkinsConfigUrl/job/MyJob)", ZulipUtil.displayItem(itemMock, descMock, true, true));
+        assertEquals("MyJobName", ZulipUtil.displayItem(itemMock, descMock, true, false));
+        assertEquals("[MyJobName](http://JenkinsConfigUrl/job/MyJob)", ZulipUtil.displayItem(itemMock, descMock, false, true));
+        assertEquals("MyJobName", ZulipUtil.displayItem(itemMock, descMock, false, false));
+
+        // Parent without a name => display the job only
+        // Not sure this can happen, but let's be safe
+        when(itemMock.getParent()).thenReturn((ItemGroup)rootItemGroupMock);
+        when(rootItemGroupMock.getDisplayName()).thenReturn(null);
+        when(rootItemGroupMock.getUrl()).thenReturn("view/RootUrl");
+        assertEquals("[MyJobName](http://JenkinsConfigUrl/job/MyJob)", ZulipUtil.displayItem(itemMock, descMock, true, true));
+        assertEquals("MyJobName", ZulipUtil.displayItem(itemMock, descMock, true, false));
+        assertEquals("[MyJobName](http://JenkinsConfigUrl/job/MyJob)", ZulipUtil.displayItem(itemMock, descMock, false, true));
+        assertEquals("MyJobName", ZulipUtil.displayItem(itemMock, descMock, false, false));
+
+        // Custom Jenkins root URL from plugin config
+        when(descMock.getJenkinsUrl()).thenReturn("http://ZulipConfigUrl/");
+        when(itemMock.getParent()).thenReturn((ItemGroup)nonRootItemGroupMock);
+        when(((Item)nonRootItemGroupMock).getParent()).thenReturn((ItemGroup)rootItemGroupMock);
+        when(rootItemGroupMock.getDisplayName()).thenReturn("RootName");
+        when(rootItemGroupMock.getUrl()).thenReturn("view/RootUrl");
+        when(nonRootItemGroupMock.getDisplayName()).thenReturn("NonRootName");
+        when(nonRootItemGroupMock.getUrl()).thenReturn("job/NonRootUrl");
+        assertEquals("[RootName](http://ZulipConfigUrl/view/RootUrl) » [NonRootName](http://ZulipConfigUrl/job/NonRootUrl) » [MyJobName](http://ZulipConfigUrl/job/MyJob)", ZulipUtil.displayItem(itemMock, descMock, true, true));
+        assertEquals("RootName » NonRootName » MyJobName", ZulipUtil.displayItem(itemMock, descMock, true, false));
+        assertEquals("[MyJobName](http://ZulipConfigUrl/job/MyJob)", ZulipUtil.displayItem(itemMock, descMock, false, true));
+        assertEquals("MyJobName", ZulipUtil.displayItem(itemMock, descMock, false, false));
+
+        // No Jenkins root URL at all
+        PowerMockito.when(jenkins.getRootUrl()).thenReturn(null);
+        when(descMock.getJenkinsUrl()).thenReturn(null);
+        when(itemMock.getParent()).thenReturn((ItemGroup)nonRootItemGroupMock);
+        when(((Item)nonRootItemGroupMock).getParent()).thenReturn((ItemGroup)rootItemGroupMock);
+        when(rootItemGroupMock.getDisplayName()).thenReturn("RootName");
+        when(rootItemGroupMock.getUrl()).thenReturn("view/RootUrl");
+        when(nonRootItemGroupMock.getDisplayName()).thenReturn("NonRootName");
+        when(nonRootItemGroupMock.getUrl()).thenReturn("job/NonRootUrl");
+        assertEquals("RootName » NonRootName » MyJobName", ZulipUtil.displayItem(itemMock, descMock, true, true));
+        assertEquals("RootName » NonRootName » MyJobName", ZulipUtil.displayItem(itemMock, descMock, true, false));
+        assertEquals("MyJobName", ZulipUtil.displayItem(itemMock, descMock, false, true));
+        assertEquals("MyJobName", ZulipUtil.displayItem(itemMock, descMock, false, false));
     }
 
 }


### PR DESCRIPTION
Fixes #31.

Use the full display name of projects in notifications instead of the "relative" name.

I.e. a job named "TestJob" in a folder named "Folder" will be displayed as "Folder » TestJob" instead of just "TestJob".

More importantly, a job for branch "production" in a multi-branch pipeline project named "TestJob" will be displayed as "TestJob » production" instead of just "production".

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
