### PR TITLE
fix(#35)!: update dependencies according new Jenkins version(2.379+)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,18 +4,18 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>3.19</version>
+    <version>4.54</version>
   </parent>
 
   <properties>
-    <jenkins.version>1.653</jenkins.version>
-    <java.level>7</java.level>
+    <jenkins.version>2.379</jenkins.version>
+    <java.level>11</java.level>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <jenkins.plugin.workflow.version>1.11</jenkins.plugin.workflow.version>
     <jenkins.plugin.structs.version>1.2</jenkins.plugin.structs.version>
     <jenkins.plugin.junit.version>1.19</jenkins.plugin.junit.version>
     <junit.version>4.12</junit.version>
-    <mockito.version>1.10.19</mockito.version>
+    <mockito.version>4.11.0</mockito.version>
     <powermock.version>1.7.4</powermock.version>
     <objenesis.version>2.6</objenesis.version>
     <mockserver.version>5.4.1</mockserver.version>
@@ -54,6 +54,12 @@
       <artifactId>junit</artifactId>
       <version>${jenkins.plugin.junit.version}</version>
     </dependency>
+    <!-- See Jenkins changelog 2.379 (2022-11-22)-->
+    <dependency>
+      <groupId>io.jenkins.plugins</groupId>
+      <artifactId>commons-httpclient3-api</artifactId>
+      <version>3.1-3</version>
+    </dependency>
     <!-- Test dependencies -->
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
@@ -69,7 +75,7 @@
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
-      <artifactId>mockito-all</artifactId>
+      <artifactId>mockito-core</artifactId>
       <version>${mockito.version}</version>
       <scope>test</scope>
     </dependency>

--- a/src/main/java/jenkins/plugins/zulip/DescriptorImpl.java
+++ b/src/main/java/jenkins/plugins/zulip/DescriptorImpl.java
@@ -45,7 +45,7 @@ public class DescriptorImpl extends BuildStepDescriptor<Publisher> {
         } else {
             XStream2 xstream = new XStream2();
             xstream.alias("hudson.plugins.humbug.DescriptorImpl", DescriptorImpl.class);
-            XmlFile oldConfig = new XmlFile(xstream, new File(Jenkins.getInstance().getRootDir(), OLD_CONFIG_FILE_NAME));
+            XmlFile oldConfig = new XmlFile(xstream, new File(Jenkins.getInstanceOrNull().getRootDir(), OLD_CONFIG_FILE_NAME));
             if (oldConfig.exists()) {
                 try {
                     oldConfig.unmarshal(this);
@@ -146,7 +146,7 @@ public class DescriptorImpl extends BuildStepDescriptor<Publisher> {
         save();
 
         // Cleanup the configuration file from previous plugin id - humbug
-        File oldConfig = new File(Jenkins.getInstance().getRootDir(), OLD_CONFIG_FILE_NAME);
+        File oldConfig = new File(Jenkins.getInstanceOrNull().getRootDir(), OLD_CONFIG_FILE_NAME);
         if (oldConfig.exists()) {
             if (oldConfig.delete()) {
                 logger.log(Level.INFO, "Old humbug configuration file successfully cleaned up.");

--- a/src/main/java/jenkins/plugins/zulip/Zulip.java
+++ b/src/main/java/jenkins/plugins/zulip/Zulip.java
@@ -50,7 +50,7 @@ public class Zulip {
      */
     protected void configureProxy(HttpClient httpClient) throws MalformedURLException {
         LOGGER.log(Level.FINE, "Setting up HttpClient proxy");
-        ProxyConfiguration proxyConfiguration = Jenkins.getInstance().proxy;
+        ProxyConfiguration proxyConfiguration = Jenkins.getInstanceOrNull().proxy;
         if (proxyConfiguration != null && ZulipUtil.isValueSet(proxyConfiguration.name)) {
             URL urlObj = new URL(url);
             Proxy proxy = proxyConfiguration.createProxy(urlObj.getHost());

--- a/src/main/java/jenkins/plugins/zulip/ZulipSendStep.java
+++ b/src/main/java/jenkins/plugins/zulip/ZulipSendStep.java
@@ -40,7 +40,7 @@ public class ZulipSendStep extends Builder implements SimpleBuildStep {
     public void perform(@Nonnull Run<?, ?> run, @Nonnull FilePath workspace, @Nonnull Launcher launcher, @Nonnull TaskListener listener)
             throws InterruptedException, IOException {
         jenkins.plugins.zulip.DescriptorImpl globalConfig =
-                Jenkins.getInstance().getDescriptorByType(jenkins.plugins.zulip.DescriptorImpl.class);
+                Jenkins.getInstanceOrNull().getDescriptorByType(jenkins.plugins.zulip.DescriptorImpl.class);
         Zulip zulip = new Zulip(globalConfig.getUrl(), globalConfig.getEmail(), globalConfig.getApiKey());
         String stream = ZulipUtil.expandVariables(run, listener, ZulipUtil.getDefaultValue(getStream(), globalConfig.getStream()));
         String defaultTopic = displayItem(run.getParent(), globalConfig, globalConfig.isFullJobPathAsDefaultTopic(), false);

--- a/src/main/java/jenkins/plugins/zulip/ZulipUtil.java
+++ b/src/main/java/jenkins/plugins/zulip/ZulipUtil.java
@@ -51,7 +51,7 @@ public class ZulipUtil {
      * @return The Jenkins instance Url
      */
     public static String getJenkinsUrl(DescriptorImpl globalConfig) {
-        String jenkinsUrl = getDefaultValue(globalConfig.getJenkinsUrl(), Jenkins.getInstance().getRootUrl());
+        String jenkinsUrl = getDefaultValue(globalConfig.getJenkinsUrl(), Jenkins.getInstanceOrNull().getRootUrl());
         if (jenkinsUrl != null && jenkinsUrl.length() > 0 && !jenkinsUrl.endsWith("/")) {
             jenkinsUrl = jenkinsUrl + "/";
         }

--- a/src/test/java/jenkins/plugins/zulip/ZulipSendStepFullJobPathTest.java
+++ b/src/test/java/jenkins/plugins/zulip/ZulipSendStepFullJobPathTest.java
@@ -25,9 +25,9 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyString;
-import static org.mockito.Matchers.eq;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -81,7 +81,7 @@ public class ZulipSendStepFullJobPathTest {
     public void setUp() throws Exception {
         PowerMockito.whenNew(Zulip.class).withAnyArguments().thenReturn(zulip);
         PowerMockito.mockStatic(Jenkins.class);
-        when(Jenkins.getInstance()).thenReturn(jenkins);
+        when(Jenkins.getInstanceOrNull()).thenReturn(jenkins);
         when(jenkins.getDescriptorByType(DescriptorImpl.class)).thenReturn(descMock);
         when(jenkins.getDisplayName()).thenReturn("Jenkins");
         when(descMock.getUrl()).thenReturn("zulipUrl");
@@ -95,7 +95,7 @@ public class ZulipSendStepFullJobPathTest {
         when(job.getParent()).thenReturn(folder);
         when(folder.getDisplayName()).thenReturn("Folder");
         when(folder.getUrl()).thenReturn("job/Folder");
-        when(folder.getParent()).thenReturn((ItemGroup)jenkins);
+        when(folder.getParent()).thenReturn((ItemGroup) jenkins);
         when(run.getEnvironment(taskListener)).thenReturn(envVars);
         when(envVars.expand(anyString())).thenAnswer(new Answer<String>() {
             @Override

--- a/src/test/java/jenkins/plugins/zulip/ZulipSendStepTest.java
+++ b/src/test/java/jenkins/plugins/zulip/ZulipSendStepTest.java
@@ -24,9 +24,9 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyString;
-import static org.mockito.Matchers.eq;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -77,7 +77,7 @@ public class ZulipSendStepTest {
     public void setUp() throws Exception {
         PowerMockito.whenNew(Zulip.class).withAnyArguments().thenReturn(zulip);
         PowerMockito.mockStatic(Jenkins.class);
-        when(Jenkins.getInstance()).thenReturn(jenkins);
+        when(Jenkins.getInstanceOrNull()).thenReturn(jenkins);
         when(jenkins.getDescriptorByType(DescriptorImpl.class)).thenReturn(descMock);
         when(descMock.getUrl()).thenReturn("zulipUrl");
         when(descMock.getEmail()).thenReturn("jenkins-bot@zulip.com");

--- a/src/test/java/jenkins/plugins/zulip/ZulipTest.java
+++ b/src/test/java/jenkins/plugins/zulip/ZulipTest.java
@@ -19,7 +19,7 @@ import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockserver.model.HttpRequest.request;
 import static org.mockserver.model.HttpResponse.response;
 import static org.mockserver.model.StringBody.exact;
@@ -50,7 +50,7 @@ public class ZulipTest {
     @Before
     public void setUp() {
         PowerMockito.mockStatic(Jenkins.class);
-        when(Jenkins.getInstance()).thenReturn(jenkins);
+        when(Jenkins.getInstanceOrNull()).thenReturn(jenkins);
         PowerMockito.mockStatic(Secret.class);
         when(Secret.toString(any(Secret.class))).thenReturn("secret");
     }

--- a/src/test/java/jenkins/plugins/zulip/ZulipUtilTest.java
+++ b/src/test/java/jenkins/plugins/zulip/ZulipUtilTest.java
@@ -39,7 +39,7 @@ public class ZulipUtilTest {
     public void setUp() {
         // Mock Jenkins Instance
         PowerMockito.mockStatic(Jenkins.class);
-        PowerMockito.when(Jenkins.getInstance()).thenReturn(jenkins);
+        PowerMockito.when(Jenkins.getInstanceOrNull()).thenReturn(jenkins);
         PowerMockito.when(jenkins.getRootUrl()).thenReturn("http://JenkinsConfigUrl");
     }
 


### PR DESCRIPTION
Hello, guys! I made a quick fix of the issue #35. I added а dependency for plugin commons-httpclient3-api to pom. I tested it in my jenkins server(v. 2.386) and it worked successful. Also I updated some dependencies and tests but tests are failed. I don't know how to fix it, I need help.
Pls, review my PR. 
Thank you!

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue