### PR TITLE
fix: java 17 authentication

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,5 +3,7 @@ buildPlugin(
   configurations: [
     [platform: 'linux', jdk: 11],
     [platform: 'windows', jdk: 11],
+    [platform: 'linux', jdk: 17],
+    [platform: 'windows', jdk: 17],
   ],
 )

--- a/src/test/java/jenkins/plugins/zulip/ZulipTest.java
+++ b/src/test/java/jenkins/plugins/zulip/ZulipTest.java
@@ -95,7 +95,8 @@ public class ZulipTest {
 
     @Test
     public void testSendsAuthorizationWhenRequested() {
-        mockServer.when(request().withPath("/api/v1/messages").withHeader(NottableString.not("Authorization")))
+        mockServer
+                .when(request().withPath("/api/v1/messages").withHeader(NottableString.not(HttpHeaders.AUTHORIZATION)))
                 .respond(response().withStatusCode(401).withHeader(HttpHeaders.WWW_AUTHENTICATE, "Basic"));
         mockServer.when(request().withPath("/api/v1/messages"))
                 .respond(response().withStatusCode(200));


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

In Java 17, the authenticator is invoked with `SERVER` requestor even when the initial request is performed and even tho we provide the preemptive authorization via header.

Since our authenticator implementaiton did not provide credentials for `SERVER` requestor, only for `PROXY`, the message sending would crash with  `java.io.IOException: No credentials provided` error.

Fixes #40 

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
